### PR TITLE
Add the missing image:ethertransaction

### DIFF
--- a/[中文]-以太坊白皮书.md
+++ b/[中文]-以太坊白皮书.md
@@ -167,6 +167,8 @@
 
 ### 以太坊状态转换函数
 
+![以太坊交易.png](https://raw.githubusercontent.com/ethereumbuilders/GitBook/master/en/vitalik-diagrams/ethertransition.png)
+
 以太坊的状态转换函数：`APPLY(S,TX) -> S'`，可以定义如下：
 
 1.  检查交易的格式是否正确（即有正确数值）、签名是否有效和随机数是否与发送者账户的随机数匹配。如否，返回错误。


### PR DESCRIPTION
Because the explanation below uses the example shown in the image,
I think it's better to add the image back.