### PR TITLE
Dead links correction in [spanish]-ethereum-toc.md

### DIFF
--- a/pages/ethereum-toc/[spanish]-ethereum-toc.md
+++ b/pages/ethereum-toc/[spanish]-ethereum-toc.md
@@ -5,20 +5,20 @@ category:
 
 ### Bienvenidos a Ethereum, la plataforma para la siguiente generación de contratos inteligentes y aplicaciones descentralizadas.
 
-[Whitepaper de Ethereum](https://google.com)
+[Whitepaper de Ethereum](https://github.com/ethereum/wiki/wiki/White-Paper)
 
-[RLP](https://google.com), Prefijo Linear Recursivo (Recursive Linear Prefix), usado para codificación de datos a través de Ethereum.
+[RLP](https://github.com/ethereum/wiki/wiki/%5BEnglish%5D-RLP), Prefijo Linear Recursivo (Recursive Linear Prefix), usado para codificación de datos a través de Ethereum.
 
-[Patricia Tree](https://google.com) especificaciones del  árbol Merkle Patricia (“Merkle Patria Tree”, también conocido como Trie), la estructura usada para almacenar y procesar a través de funciones Hash el estado de la cadena de bloques en Ethereum.
+[Patricia Tree](https://github.com/ethereum/wiki/wiki/%5BEnglish%5D-Patricia-Tree) especificaciones del  árbol Merkle Patricia (“Merkle Patria Tree”, también conocido como Trie), la estructura usada para almacenar y procesar a través de funciones Hash el estado de la cadena de bloques en Ethereum.
 
-[Protocolo de conexión](https://google.com), especificaciones.
+[Protocolo de conexión](https://github.com/ethereum/wiki/wiki/Ethereum-Wire-Protocol), especificaciones.
 
-[CLL](https://google.com), Lenguage de alto nivel similar a C usado para crear contratos, especificaciones.
+[CLL](https://github.com/ethereum/wiki/blob/master/CLL.md), Lenguage de alto nivel similar a C usado para crear contratos, especificaciones.
 
-[Dagger](https://google.com), Prueba de trabajo (Proof-of-work) de Ethereum.
+[Dagger](https://github.com/ethereum/wiki/blob/master/Dagger.md), Prueba de trabajo (Proof-of-work) de Ethereum.
 
-[Protocolo de Bloques 2.0](https://google.com)
+[Protocolo de Bloques 2.0](https://github.com/ethereum/wiki/blob/master/Block-Protocol-2.0.md)
 
-[Capas](https://google.com)
+[Capas](https://github.com/ethereum/wiki/blob/master/Layers.md)
 
-[Cámara de compensación](https://google.com)
+[Cámara de compensación](https://github.com/ethereum/wiki/blob/master/Clearinghouse.md)


### PR DESCRIPTION
Updated links that only redirected to google.com on the Spanish Ethereum TOC to their respective pages.