### PR TITLE
Fixed a dead "Solidity documentation" link

### DIFF
--- a/Dapp-Developer-Resources.md
+++ b/Dapp-Developer-Resources.md
@@ -4,7 +4,7 @@ As a Ðapp developer you have three main resources which allow Ðapp development
 
 - [Web3 JavaScript API](https://github.com/ethereum/wiki/wiki/JavaScript-API) - This is the main JavaScript SDK to use when you want to interact with a nodes API
 - [JSON RPC API](https://github.com/ethereum/wiki/wiki/JSON-RPC) - This is the low level JSON RPC 2.0 interface to interface with a node. This API is used by the [Web3 JavaScript API](https://github.com/ethereum/wiki/wiki/JavaScript-API).
-- [Solidity Documentation](https://ethereum.github.io/solidity/docs/home/) - Solidity is the Ethereum developed Smart Contract language, which compiles to EVM (Ethereum Virtual Machine) opcodes.
+- [Solidity Documentation](https://solidity.readthedocs.io/en/latest/) - Solidity is the Ethereum developed Smart Contract language, which compiles to EVM (Ethereum Virtual Machine) opcodes.
 
 ### Other Resources:
 


### PR DESCRIPTION
Replaced the dead "https://ethereum.github.io/solidity/docs/home/" link with a working link.