### PR TITLE
Create CC0-LICENSE

### DIFF
--- a/CC0-LICENSE
+++ b/CC0-LICENSE
@@ -1,0 +1,1 @@
+The license for this wiki repository is CC0. A human-readable version of the license is available [here](https://creativecommons.org/publicdomain/zero/1.0/), which also directs to the full license.


### PR DESCRIPTION
Creating a CC0 license allows for the content of this wiki to be placed in the public domain. This will help to allow for the dissemination of information about Ethereum, the Ethereum ecosystem and Web 3 to the public, in a completely permissive manner. I have updated the [home page](https://github.com/ethereum/wiki/wiki) and created a [CC0 license](https://github.com/ethereum/wiki/wiki/CC0-license) page, adding a contributor license agreement to help enable future changes to be under a CC0 license and referring to this PR to acknowledge those who have and have not agreed to a CC0 license, where those who have not agreed to a CC0 license have all rights reserved for their contributions.